### PR TITLE
fix(ingestor): add extend_schema option to summary rule .set-or-append operation

### DIFF
--- a/ingestor/adx/tasks.go
+++ b/ingestor/adx/tasks.go
@@ -544,7 +544,7 @@ func (t *SummaryRuleTask) submitRule(ctx context.Context, rule v1.SummaryRule, s
 	body := kustoutil.ApplySubstitutions(rule.Spec.Body, startTime, endTime, t.ClusterLabels)
 
 	// Execute asynchronously
-	stmt := kql.New(".set-or-append async ").AddUnsafe(rule.Spec.Table).AddLiteral(" <| ").AddUnsafe(body)
+	stmt := kql.New(".set-or-append async ").AddUnsafe(rule.Spec.Table).AddLiteral(" with (extend_schema=true) <| ").AddUnsafe(body)
 	res, err := t.kustoCli.Mgmt(ctx, stmt)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute summary rule %s.%s: %w", rule.Spec.Database, rule.Name, err)


### PR DESCRIPTION
If summary rules are updated in a way that changes the schema, they end up erroring out with something like this:

```
Query schema does not match table schema. QuerySchema=('string,datetime,string,string,string,string'), TableSchema=('datetime,string,string,string,string')
```

By setting extend_schema, we can at least allow new fields to be added to the summary rule. While this doesn't allow removing or changing columns, it at least gives an out for adding additional columns.